### PR TITLE
ported to dwn 0.0.17-unstable.4deecf8-2023.1.17-19-06-19 and fixed duplicated todo upon refresh

### DIFF
--- a/message-store-level-v2/package-lock.json
+++ b/message-store-level-v2/package-lock.json
@@ -15,7 +15,7 @@
                 "level": "8.0.0",
                 "lodash": "4.17.21",
                 "multiformats": "10.0.3",
-                "search-index": "3.3.0"
+                "search-index": "3.1.3"
             },
             "devDependencies": {
                 "@esbuild-plugins/node-globals-polyfill": "0.1.1",
@@ -535,6 +535,30 @@
                 "node": ">=12"
             }
         },
+        "node_modules/abstract-leveldown": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
+            "dependencies": {
+                "buffer": "^6.0.3",
+                "catering": "^2.0.0",
+                "is-buffer": "^2.0.5",
+                "level-concat-iterator": "^3.0.0",
+                "level-supports": "^2.0.1",
+                "queue-microtask": "^1.2.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/abstract-leveldown/node_modules/level-supports": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -607,9 +631,9 @@
             }
         },
         "node_modules/cborg": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
-            "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ==",
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+            "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==",
             "bin": {
                 "cborg": "cli.js"
             }
@@ -649,6 +673,32 @@
                 "supports-color": {
                     "optional": true
                 }
+            }
+        },
+        "node_modules/deferred-leveldown": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
+            "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
+            "dependencies": {
+                "abstract-leveldown": "^7.2.0",
+                "inherits": "^2.0.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/encoding-down": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
+            "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
+            "dependencies": {
+                "abstract-leveldown": "^7.2.0",
+                "inherits": "^2.0.3",
+                "level-codec": "^10.0.0",
+                "level-errors": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/err-code": {
@@ -717,14 +767,15 @@
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
         },
         "node_modules/fergies-inverted-index": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.1.0.tgz",
-            "integrity": "sha512-VfaC9lqbRqBZdZoNi5rq4bWVPnvURRB1k41/QWdj9RPBJvUZsMWj9btjVyh3pgspm4dk9x4kHY1OZoZih+6GUA==",
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.0.6.tgz",
+            "integrity": "sha512-T0dXoUk7XYr/N4Vgcw8MDoKtSUedYp9KxPvyYLSFbqIxDoOBPXpOktSTDaA6ToU9u9o/7u4FXtd9vJ4AoQejZg==",
             "dependencies": {
-                "browser-level": "^1.0.1",
                 "charwise": "^3.0.1",
-                "classic-level": "^1.2.0",
-                "level-read-stream": "^1.1.0",
+                "encoding-down": "^7.1.0",
+                "level-js": "^6.1.0",
+                "leveldown": "^6.1.0",
+                "levelup": "^5.1.1",
                 "traverse": "^0.6.6"
             }
         },
@@ -942,23 +993,58 @@
                 "url": "https://opencollective.com/level"
             }
         },
-        "node_modules/level-read-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/level-read-stream/-/level-read-stream-1.1.0.tgz",
-            "integrity": "sha512-pVRftTUgsJHH3O1o+cXRTZuRGPnTMyuocxpfl+b5L/papZhV810zhunAxn4mgvfDWzqxM5Df76z7C1Y0QQSLBw==",
+        "node_modules/level-codec": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
+            "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
             "dependencies": {
+                "buffer": "^6.0.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/level-concat-iterator": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
+            "dependencies": {
+                "catering": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/level-errors": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
+            "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/level-iterator-stream": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
+            "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
+            "dependencies": {
+                "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
             },
             "engines": {
-                "node": ">=12"
-            },
-            "peerDependencies": {
-                "abstract-level": "^1.0.0"
-            },
-            "peerDependenciesMeta": {
-                "abstract-level": {
-                    "optional": true
-                }
+                "node": ">=10"
+            }
+        },
+        "node_modules/level-js": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
+            "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
+            "dependencies": {
+                "abstract-leveldown": "^7.2.0",
+                "buffer": "^6.0.3",
+                "inherits": "^2.0.3",
+                "ltgt": "^2.1.2",
+                "run-parallel-limit": "^1.1.0"
             }
         },
         "node_modules/level-supports": {
@@ -981,6 +1067,44 @@
                 "node": ">=12"
             }
         },
+        "node_modules/leveldown": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
+            "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
+            "hasInstallScript": true,
+            "dependencies": {
+                "abstract-leveldown": "^7.2.0",
+                "napi-macros": "~2.0.0",
+                "node-gyp-build": "^4.3.0"
+            },
+            "engines": {
+                "node": ">=10.12.0"
+            }
+        },
+        "node_modules/levelup": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
+            "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
+            "dependencies": {
+                "catering": "^2.0.0",
+                "deferred-leveldown": "^7.0.0",
+                "level-errors": "^3.0.1",
+                "level-iterator-stream": "^5.0.0",
+                "level-supports": "^2.0.1",
+                "queue-microtask": "^1.2.3"
+            },
+            "engines": {
+                "node": ">=10"
+            }
+        },
+        "node_modules/levelup/node_modules/level-supports": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+            "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA==",
+            "engines": {
+                "node": ">=10"
+            }
+        },
         "node_modules/lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -998,6 +1122,11 @@
             "engines": {
                 "node": ">=12"
             }
+        },
+        "node_modules/ltgt": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+            "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA=="
         },
         "node_modules/magic-string": {
             "version": "0.25.9",
@@ -1068,9 +1197,9 @@
             "integrity": "sha512-+9RehP0EFeNxCyD53aeSFvF3OU6V0zcoZNRCXxvISl+nnlFcIZxSYdGhPaq8NDJTGlA4Ej5+NlkGopRSuuAwfw=="
         },
         "node_modules/node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "2.6.8",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+            "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
             "dependencies": {
                 "whatwg-url": "^5.0.0"
             },
@@ -1087,9 +1216,9 @@
             }
         },
         "node_modules/node-gyp-build": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+            "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
             "bin": {
                 "node-gyp-build": "bin.js",
                 "node-gyp-build-optional": "optional.js",
@@ -1267,14 +1396,13 @@
             ]
         },
         "node_modules/search-index": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.3.0.tgz",
-            "integrity": "sha512-VJJfhXGXdwtu7/lf/bDMb4gN3mqXhSm57VUZBzRsOtIDvTVSPaOWJZYfruMIqutp+N4aLdUOUfWhB02MClmIJQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.1.3.tgz",
+            "integrity": "sha512-kck7BEbdmVV2NVIHCTg27I6NTDSQiyC1y/YTazmlzTN7+6o43eie0Vd3HBVyoqzDV0CnQeGv1k3XCDNo6mIaYQ==",
             "dependencies": {
-                "browser-level": "^1.0.1",
-                "classic-level": "^1.2.0",
-                "fergies-inverted-index": "^10.1.0",
-                "level-read-stream": "^1.1.0",
+                "fergies-inverted-index": "10.0.6",
+                "level-js": "^6.1.0",
+                "leveldown": "^6.1.1",
                 "lru-cache": "^7.9.0",
                 "ngraminator": "^3.0.1",
                 "p-queue": "^7.2.0",
@@ -1667,6 +1795,26 @@
                 "queue-microtask": "^1.2.3"
             }
         },
+        "abstract-leveldown": {
+            "version": "7.2.0",
+            "resolved": "https://registry.npmjs.org/abstract-leveldown/-/abstract-leveldown-7.2.0.tgz",
+            "integrity": "sha512-DnhQwcFEaYsvYDnACLZhMmCWd3rkOeEvglpa4q5i/5Jlm3UIsWaxVzuXvDLFCSCWRO3yy2/+V/G7FusFgejnfQ==",
+            "requires": {
+                "buffer": "^6.0.3",
+                "catering": "^2.0.0",
+                "is-buffer": "^2.0.5",
+                "level-concat-iterator": "^3.0.0",
+                "level-supports": "^2.0.1",
+                "queue-microtask": "^1.2.3"
+            },
+            "dependencies": {
+                "level-supports": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+                    "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA=="
+                }
+            }
+        },
         "base64-js": {
             "version": "1.5.1",
             "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
@@ -1708,9 +1856,9 @@
             "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="
         },
         "cborg": {
-            "version": "1.9.6",
-            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
-            "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ=="
+            "version": "1.10.0",
+            "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+            "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ=="
         },
         "charwise": {
             "version": "3.0.1",
@@ -1735,6 +1883,26 @@
             "integrity": "sha512-PRWFHuSU3eDtQJPvnNY7Jcket1j0t5OuOsFzPPzsekD52Zl8qUfFIPEiswXqIvHWGVHOgX+7G/vCNNhehwxfkQ==",
             "requires": {
                 "ms": "2.1.2"
+            }
+        },
+        "deferred-leveldown": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/deferred-leveldown/-/deferred-leveldown-7.0.0.tgz",
+            "integrity": "sha512-QKN8NtuS3BC6m0B8vAnBls44tX1WXAFATUsJlruyAYbZpysWV3siH6o/i3g9DCHauzodksO60bdj5NazNbjCmg==",
+            "requires": {
+                "abstract-leveldown": "^7.2.0",
+                "inherits": "^2.0.3"
+            }
+        },
+        "encoding-down": {
+            "version": "7.1.0",
+            "resolved": "https://registry.npmjs.org/encoding-down/-/encoding-down-7.1.0.tgz",
+            "integrity": "sha512-ky47X5jP84ryk5EQmvedQzELwVJPjCgXDQZGeb9F6r4PdChByCGHTBrVcF3h8ynKVJ1wVbkxTsDC8zBROPypgQ==",
+            "requires": {
+                "abstract-leveldown": "^7.2.0",
+                "inherits": "^2.0.3",
+                "level-codec": "^10.0.0",
+                "level-errors": "^3.0.0"
             }
         },
         "err-code": {
@@ -1790,14 +1958,15 @@
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
         },
         "fergies-inverted-index": {
-            "version": "10.1.0",
-            "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.1.0.tgz",
-            "integrity": "sha512-VfaC9lqbRqBZdZoNi5rq4bWVPnvURRB1k41/QWdj9RPBJvUZsMWj9btjVyh3pgspm4dk9x4kHY1OZoZih+6GUA==",
+            "version": "10.0.6",
+            "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.0.6.tgz",
+            "integrity": "sha512-T0dXoUk7XYr/N4Vgcw8MDoKtSUedYp9KxPvyYLSFbqIxDoOBPXpOktSTDaA6ToU9u9o/7u4FXtd9vJ4AoQejZg==",
             "requires": {
-                "browser-level": "^1.0.1",
                 "charwise": "^3.0.1",
-                "classic-level": "^1.2.0",
-                "level-read-stream": "^1.1.0",
+                "encoding-down": "^7.1.0",
+                "level-js": "^6.1.0",
+                "leveldown": "^6.1.0",
+                "levelup": "^5.1.1",
                 "traverse": "^0.6.6"
             }
         },
@@ -1964,12 +2133,46 @@
                 "classic-level": "^1.2.0"
             }
         },
-        "level-read-stream": {
-            "version": "1.1.0",
-            "resolved": "https://registry.npmjs.org/level-read-stream/-/level-read-stream-1.1.0.tgz",
-            "integrity": "sha512-pVRftTUgsJHH3O1o+cXRTZuRGPnTMyuocxpfl+b5L/papZhV810zhunAxn4mgvfDWzqxM5Df76z7C1Y0QQSLBw==",
+        "level-codec": {
+            "version": "10.0.0",
+            "resolved": "https://registry.npmjs.org/level-codec/-/level-codec-10.0.0.tgz",
+            "integrity": "sha512-QW3VteVNAp6c/LuV6nDjg7XDXx9XHK4abmQarxZmlRSDyXYk20UdaJTSX6yzVvQ4i0JyWSB7jert0DsyD/kk6g==",
             "requires": {
+                "buffer": "^6.0.3"
+            }
+        },
+        "level-concat-iterator": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/level-concat-iterator/-/level-concat-iterator-3.1.0.tgz",
+            "integrity": "sha512-BWRCMHBxbIqPxJ8vHOvKUsaO0v1sLYZtjN3K2iZJsRBYtp+ONsY6Jfi6hy9K3+zolgQRryhIn2NRZjZnWJ9NmQ==",
+            "requires": {
+                "catering": "^2.1.0"
+            }
+        },
+        "level-errors": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/level-errors/-/level-errors-3.0.1.tgz",
+            "integrity": "sha512-tqTL2DxzPDzpwl0iV5+rBCv65HWbHp6eutluHNcVIftKZlQN//b6GEnZDM2CvGZvzGYMwyPtYppYnydBQd2SMQ=="
+        },
+        "level-iterator-stream": {
+            "version": "5.0.0",
+            "resolved": "https://registry.npmjs.org/level-iterator-stream/-/level-iterator-stream-5.0.0.tgz",
+            "integrity": "sha512-wnb1+o+CVFUDdiSMR/ZymE2prPs3cjVLlXuDeSq9Zb8o032XrabGEXcTCsBxprAtseO3qvFeGzh6406z9sOTRA==",
+            "requires": {
+                "inherits": "^2.0.4",
                 "readable-stream": "^3.4.0"
+            }
+        },
+        "level-js": {
+            "version": "6.1.0",
+            "resolved": "https://registry.npmjs.org/level-js/-/level-js-6.1.0.tgz",
+            "integrity": "sha512-i7mPtkZm68aewfv0FnIUWvFUFfoyzIvVKnUmuQGrelEkP72vSPTaA1SGneWWoCV5KZJG4wlzbJLp1WxVNGuc6A==",
+            "requires": {
+                "abstract-leveldown": "^7.2.0",
+                "buffer": "^6.0.3",
+                "inherits": "^2.0.3",
+                "ltgt": "^2.1.2",
+                "run-parallel-limit": "^1.1.0"
             }
         },
         "level-supports": {
@@ -1986,6 +2189,36 @@
                 "module-error": "^1.0.1"
             }
         },
+        "leveldown": {
+            "version": "6.1.1",
+            "resolved": "https://registry.npmjs.org/leveldown/-/leveldown-6.1.1.tgz",
+            "integrity": "sha512-88c+E+Eizn4CkQOBHwqlCJaTNEjGpaEIikn1S+cINc5E9HEvJ77bqY4JY/HxT5u0caWqsc3P3DcFIKBI1vHt+A==",
+            "requires": {
+                "abstract-leveldown": "^7.2.0",
+                "napi-macros": "~2.0.0",
+                "node-gyp-build": "^4.3.0"
+            }
+        },
+        "levelup": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/levelup/-/levelup-5.1.1.tgz",
+            "integrity": "sha512-0mFCcHcEebOwsQuk00WJwjLI6oCjbBuEYdh/RaRqhjnyVlzqf41T1NnDtCedumZ56qyIh8euLFDqV1KfzTAVhg==",
+            "requires": {
+                "catering": "^2.0.0",
+                "deferred-leveldown": "^7.0.0",
+                "level-errors": "^3.0.1",
+                "level-iterator-stream": "^5.0.0",
+                "level-supports": "^2.0.1",
+                "queue-microtask": "^1.2.3"
+            },
+            "dependencies": {
+                "level-supports": {
+                    "version": "2.1.0",
+                    "resolved": "https://registry.npmjs.org/level-supports/-/level-supports-2.1.0.tgz",
+                    "integrity": "sha512-E486g1NCjW5cF78KGPrMDRBYzPuueMZ6VBXHT6gC7A8UYWGiM14fGgp+s/L1oFfDWSPV/+SFkYCmZ0SiESkRKA=="
+                }
+            }
+        },
         "lodash": {
             "version": "4.17.21",
             "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
@@ -2000,6 +2233,11 @@
             "version": "7.14.1",
             "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-7.14.1.tgz",
             "integrity": "sha512-ysxwsnTKdAx96aTRdhDOCQfDgbHnt8SK0KY8SEjO0wHinhWOFTESbjVCMPbU1uGXg/ch4lifqx0wfjOawU2+WA=="
+        },
+        "ltgt": {
+            "version": "2.2.1",
+            "resolved": "https://registry.npmjs.org/ltgt/-/ltgt-2.2.1.tgz",
+            "integrity": "sha512-AI2r85+4MquTw9ZYqabu4nMwy9Oftlfa/e/52t9IjtfG+mGBbTNdAoZ3RQKLHR6r0wQnwZnPIEh/Ya6XTWAKNA=="
         },
         "magic-string": {
             "version": "0.25.9",
@@ -2054,17 +2292,17 @@
             "integrity": "sha512-+9RehP0EFeNxCyD53aeSFvF3OU6V0zcoZNRCXxvISl+nnlFcIZxSYdGhPaq8NDJTGlA4Ej5+NlkGopRSuuAwfw=="
         },
         "node-fetch": {
-            "version": "2.6.7",
-            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.7.tgz",
-            "integrity": "sha512-ZjMPFEfVx5j+y2yF35Kzx5sF7kDzxuDj6ziH4FFbOp87zKDZNx8yExJIb05OGF4Nlt9IHFIMBkRl41VdvcNdbQ==",
+            "version": "2.6.8",
+            "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-2.6.8.tgz",
+            "integrity": "sha512-RZ6dBYuj8dRSfxpUSu+NsdF1dpPpluJxwOp+6IoDp/sH2QNDSvurYsAa+F1WxY2RjA1iP93xhcsUoYbF2XBqVg==",
             "requires": {
                 "whatwg-url": "^5.0.0"
             }
         },
         "node-gyp-build": {
-            "version": "4.5.0",
-            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-            "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+            "version": "4.6.0",
+            "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+            "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
         },
         "p-queue": {
             "version": "7.3.0",
@@ -2171,14 +2409,13 @@
             "integrity": "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="
         },
         "search-index": {
-            "version": "3.3.0",
-            "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.3.0.tgz",
-            "integrity": "sha512-VJJfhXGXdwtu7/lf/bDMb4gN3mqXhSm57VUZBzRsOtIDvTVSPaOWJZYfruMIqutp+N4aLdUOUfWhB02MClmIJQ==",
+            "version": "3.1.3",
+            "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.1.3.tgz",
+            "integrity": "sha512-kck7BEbdmVV2NVIHCTg27I6NTDSQiyC1y/YTazmlzTN7+6o43eie0Vd3HBVyoqzDV0CnQeGv1k3XCDNo6mIaYQ==",
             "requires": {
-                "browser-level": "^1.0.1",
-                "classic-level": "^1.2.0",
-                "fergies-inverted-index": "^10.1.0",
-                "level-read-stream": "^1.1.0",
+                "fergies-inverted-index": "10.0.6",
+                "level-js": "^6.1.0",
+                "leveldown": "^6.1.1",
                 "lru-cache": "^7.9.0",
                 "ngraminator": "^3.0.1",
                 "p-queue": "^7.2.0",

--- a/message-store-level-v2/package.json
+++ b/message-store-level-v2/package.json
@@ -13,7 +13,7 @@
         "ipfs-unixfs-importer": "9.0.10",
         "@ipld/dag-cbor": "8.0.0",
         "@js-temporal/polyfill": "0.4.3",
-        "search-index": "3.3.0",
+        "search-index": "3.1.3",
         "level": "8.0.0",
         "multiformats": "10.0.3"
     },
@@ -21,6 +21,9 @@
     "main": "./src/index.js",
     "browser": {
         "./src/index.js": "./dist/browser.js"
+    },
+    "scripts": {
+        "build": "rm -rf ./dist && node bundle.js"
     },
     "files": [
         "src",

--- a/todo-app/src/App.vue
+++ b/todo-app/src/App.vue
@@ -85,7 +85,6 @@ async function addTodo() {
 }
 
 async function toggleTodoComplete(todoRecordId) {
-  console.log('hello?');
   let toggledTodo;
   let updatedTodoData;
 
@@ -100,17 +99,6 @@ async function toggleTodoComplete(todoRecordId) {
   }
 
   const { descriptor } = toggledTodo.dWebMessage;
-
-  console.log({
-    method  : 'CollectionsWrite',
-    data    : updatedTodoData,
-    message : {
-      recordId    : toggledTodo.dWebMessage.recordId,
-      dateCreated : descriptor.dateCreated,
-      schema      : descriptor.schema,
-      dataFormat  : descriptor.dataFormat,
-    }
-  });
 
   const result = await window.web5.dwn.processMessage({
     method  : 'CollectionsWrite',

--- a/web5-wallet/background/web5-message-handlers/dwn/process-message/collections-query.js
+++ b/web5-wallet/background/web5-message-handlers/dwn/process-message/collections-query.js
@@ -9,11 +9,13 @@ import * as DWN from '../../../dwn';
 export async function handleCollectionsQuery(ctx, data) {
   const { profile, signatureMaterial } = ctx;
   
-  const collectionsQuery = await CollectionsQuery.create({
+  const queryOptions = {
     ...data.message,
     target         : profile.did,
     signatureInput : signatureMaterial
-  });
+  };
+  const collectionsQuery = await CollectionsQuery.create(queryOptions);
+  console.log(collectionsQuery.message);
 
   const dwn = await DWN.open();
   const result =  await dwn.processMessage(collectionsQuery.toJSON());

--- a/web5-wallet/background/web5-message-handlers/dwn/process-message/collections-query.js
+++ b/web5-wallet/background/web5-message-handlers/dwn/process-message/collections-query.js
@@ -15,7 +15,6 @@ export async function handleCollectionsQuery(ctx, data) {
     signatureInput : signatureMaterial
   };
   const collectionsQuery = await CollectionsQuery.create(queryOptions);
-  console.log(collectionsQuery.message);
 
   const dwn = await DWN.open();
   const result =  await dwn.processMessage(collectionsQuery.toJSON());

--- a/web5-wallet/background/web5-message-handlers/dwn/process-message/collections-write.js
+++ b/web5-wallet/background/web5-message-handlers/dwn/process-message/collections-write.js
@@ -26,6 +26,9 @@ export async function handleCollectionsWrite(ctx, data) {
   }
 
   let collectionsWrite;
+
+  // the following conditional is a convenience provided via the web5 api to clobber a
+  // `CollectionsWrite` without having to manually copy over the immutable properties
   // if this is the initial write
   if (data.baseEntry === undefined) {
     console.log('Initial CollectionsWrite');
@@ -49,9 +52,6 @@ export async function handleCollectionsWrite(ctx, data) {
   }
 
   const collectionsWriteJSON = collectionsWrite.toJSON();
-  console.log(collectionsWriteJSON);
-  console.log(JSON.stringify(collectionsWriteJSON));
-
 
   const dwn = await DWN.open();
   const result = await dwn.processMessage(collectionsWriteJSON);

--- a/web5-wallet/package-lock.json
+++ b/web5-wallet/package-lock.json
@@ -13,7 +13,7 @@
         "@heroicons/vue": "2.0.13",
         "@js-temporal/polyfill": "0.4.3",
         "@noble/ed25519": "1.6.0",
-        "@tbd54566975/dwn-sdk-js": "0.0.16",
+        "@tbd54566975/dwn-sdk-js": "0.0.17-unstable.4deecf8-2023.1.17-19-06-19",
         "dayjs": "1.11.7",
         "eventemitter3": "4.0.7",
         "message-store-level-v2": "file:../message-store-level-v2",
@@ -767,9 +767,9 @@
       }
     },
     "node_modules/@tbd54566975/dwn-sdk-js": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.16.tgz",
-      "integrity": "sha512-ZeYUO6trrstaimF/cSrQ1fhRAnGnCS7aDR4C93S3w3BDJSwEtGAF55NH2yNTgZYoE6EkFPBmCoVqGEkgoc1NIw==",
+      "version": "0.0.17-unstable.4deecf8-2023.1.17-19-06-19",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.17-unstable.4deecf8-2023.1.17-19-06-19.tgz",
+      "integrity": "sha512-LDCE8oo87bFcffYO61KMEwAd6GmTSNFQcfAoxjXAcGt4fvcaJKvENUlkKTwJVa5y6eKBBSgzW/GXTX2ZM7lRgw==",
       "dependencies": {
         "@ipld/dag-cbor": "7.0.1",
         "@js-temporal/polyfill": "0.4.3",
@@ -8050,9 +8050,9 @@
       }
     },
     "@tbd54566975/dwn-sdk-js": {
-      "version": "0.0.16",
-      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.16.tgz",
-      "integrity": "sha512-ZeYUO6trrstaimF/cSrQ1fhRAnGnCS7aDR4C93S3w3BDJSwEtGAF55NH2yNTgZYoE6EkFPBmCoVqGEkgoc1NIw==",
+      "version": "0.0.17-unstable.4deecf8-2023.1.17-19-06-19",
+      "resolved": "https://registry.npmjs.org/@tbd54566975/dwn-sdk-js/-/dwn-sdk-js-0.0.17-unstable.4deecf8-2023.1.17-19-06-19.tgz",
+      "integrity": "sha512-LDCE8oo87bFcffYO61KMEwAd6GmTSNFQcfAoxjXAcGt4fvcaJKvENUlkKTwJVa5y6eKBBSgzW/GXTX2ZM7lRgw==",
       "requires": {
         "@ipld/dag-cbor": "7.0.1",
         "@js-temporal/polyfill": "0.4.3",

--- a/web5-wallet/package-lock.json
+++ b/web5-wallet/package-lock.json
@@ -502,9 +502,9 @@
       }
     },
     "node_modules/@eslint/eslintrc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
-      "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
       "dev": true,
       "dependencies": {
         "ajv": "^6.12.4",
@@ -860,9 +860,9 @@
       }
     },
     "node_modules/@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "version": "4.17.32",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz",
+      "integrity": "sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==",
       "dependencies": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -1717,9 +1717,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001441",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+      "version": "1.0.30001445",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+      "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
       "dev": true,
       "funding": [
         {
@@ -1746,9 +1746,9 @@
       }
     },
     "node_modules/cborg": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
-      "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ==",
       "bin": {
         "cborg": "cli.js"
       }
@@ -2350,27 +2350,33 @@
       }
     },
     "node_modules/es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
       "dev": true,
       "dependencies": {
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
@@ -2379,13 +2385,29 @@
         "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
-        "unbox-primitive": "^1.0.2"
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
       },
       "engines": {
         "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "dependencies": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.4"
       }
     },
     "node_modules/es-shim-unscopables": {
@@ -2544,13 +2566,14 @@
       }
     },
     "node_modules/eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
       "dependencies": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       }
     },
     "node_modules/eslint-import-resolver-node/node_modules/debug": {
@@ -2967,9 +2990,9 @@
       "dev": true
     },
     "node_modules/fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "dependencies": {
         "reusify": "^1.0.4"
@@ -3380,6 +3403,21 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "dependencies": {
+        "define-properties": "^1.1.3"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -3478,6 +3516,18 @@
       "integrity": "sha512-62DVLZGoiEBDHQyqG4w9xCuZ7eJEwNmJRWw2VY84Oedb7WFcA27fiEVe8oUQx9hAUJ4ekurquucTGwsyO1XGdQ==",
       "dependencies": {
         "get-intrinsic": "^1.1.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true,
+      "engines": {
+        "node": ">= 0.4"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3752,6 +3802,20 @@
       },
       "engines": {
         "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
       },
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -4154,9 +4218,9 @@
       "dev": true
     },
     "node_modules/json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "dependencies": {
         "minimist": "^1.2.0"
@@ -4357,25 +4421,6 @@
       },
       "engines": {
         "node": ">=6"
-      }
-    },
-    "node_modules/level-read-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/level-read-stream/-/level-read-stream-1.1.0.tgz",
-      "integrity": "sha512-pVRftTUgsJHH3O1o+cXRTZuRGPnTMyuocxpfl+b5L/papZhV810zhunAxn4mgvfDWzqxM5Df76z7C1Y0QQSLBw==",
-      "dependencies": {
-        "readable-stream": "^3.4.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "peerDependencies": {
-        "abstract-level": "^1.0.0"
-      },
-      "peerDependenciesMeta": {
-        "abstract-level": {
-          "optional": true
-        }
       }
     },
     "node_modules/level-supports": {
@@ -4602,7 +4647,7 @@
         "level": "8.0.0",
         "lodash": "4.17.21",
         "multiformats": "10.0.3",
-        "search-index": "3.3.0"
+        "search-index": "3.1.3"
       }
     },
     "node_modules/message-store-level-v2/node_modules/@ipld/dag-cbor": {
@@ -4618,18 +4663,6 @@
         "npm": ">=7.0.0"
       }
     },
-    "node_modules/message-store-level-v2/node_modules/fergies-inverted-index": {
-      "version": "10.2.0",
-      "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.2.0.tgz",
-      "integrity": "sha512-9j3Ckf8f0ydvt3JK5JyqQjiyPlR8H5HtLMV+RPJrpb6XRimM6OpKbA9pTsKNu0gpQdG5ezI9ld0ZrC9/FdksjQ==",
-      "dependencies": {
-        "browser-level": "^1.0.1",
-        "charwise": "^3.0.1",
-        "classic-level": "^1.2.0",
-        "level-read-stream": "^1.1.0",
-        "traverse": "^0.6.6"
-      }
-    },
     "node_modules/message-store-level-v2/node_modules/multiformats": {
       "version": "10.0.3",
       "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
@@ -4637,50 +4670,6 @@
       "engines": {
         "node": ">=16.0.0",
         "npm": ">=7.0.0"
-      }
-    },
-    "node_modules/message-store-level-v2/node_modules/p-queue": {
-      "version": "7.3.0",
-      "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-      "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
-      "dependencies": {
-        "eventemitter3": "^4.0.7",
-        "p-timeout": "^5.0.2"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/message-store-level-v2/node_modules/p-timeout": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-      "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew==",
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/message-store-level-v2/node_modules/search-index": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.3.0.tgz",
-      "integrity": "sha512-VJJfhXGXdwtu7/lf/bDMb4gN3mqXhSm57VUZBzRsOtIDvTVSPaOWJZYfruMIqutp+N4aLdUOUfWhB02MClmIJQ==",
-      "dependencies": {
-        "browser-level": "^1.0.1",
-        "classic-level": "^1.2.0",
-        "fergies-inverted-index": "^10.1.0",
-        "level-read-stream": "^1.1.0",
-        "lru-cache": "^7.9.0",
-        "ngraminator": "^3.0.1",
-        "p-queue": "^7.2.0",
-        "term-vector": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=12"
       }
     },
     "node_modules/methods": {
@@ -4913,9 +4902,9 @@
       }
     },
     "node_modules/node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg==",
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ==",
       "bin": {
         "node-gyp-build": "bin.js",
         "node-gyp-build-optional": "optional.js",
@@ -4976,9 +4965,9 @@
       }
     },
     "node_modules/object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -5253,9 +5242,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "funding": [
         {
           "type": "opencollective",
@@ -6015,9 +6004,9 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "node_modules/punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
+      "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw==",
       "engines": {
         "node": ">=6"
       }
@@ -6298,9 +6287,9 @@
       }
     },
     "node_modules/rollup": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.0.tgz",
-      "integrity": "sha512-nGGylpmblyjTpF4lEUPgmOw6OVxRvnI6Iuuh6Lz4O/X66cVOX1XJSsqP1YamxQ+mPuFE7qJxLFDSCk8rNv5dDw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.10.0.tgz",
+      "integrity": "sha512-JmRYz44NjC1MjVF2VKxc0M1a97vn+cDxeqWmnwyAF4FvpjK8YFdHpaqvQB+3IxCvX05vJxKZkoMDU8TShhmJVA==",
       "dev": true,
       "bin": {
         "rollup": "dist/bin/rollup"
@@ -7170,6 +7159,20 @@
         "node": ">= 0.6"
       }
     },
+    "node_modules/typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "dependencies": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
     "node_modules/uint8arrays": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -7337,9 +7340,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.3.tgz",
-      "integrity": "sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
+      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
       "dev": true,
       "dependencies": {
         "esbuild": "^0.16.3",
@@ -7834,9 +7837,9 @@
       "optional": true
     },
     "@eslint/eslintrc": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.0.tgz",
-      "integrity": "sha512-7yfvXy6MWLgWSFsLhz5yH3iQ52St8cdUY6FoGieKkRDVxuxmrNuUetIuu6cmjNWwniUHiWXjxCr5tTXDrbYS5A==",
+      "version": "1.4.1",
+      "resolved": "https://registry.npmjs.org/@eslint/eslintrc/-/eslintrc-1.4.1.tgz",
+      "integrity": "sha512-XXrH9Uarn0stsyldqDYq8r++mROmWRI1xKMXa640Bb//SY1+ECYX6VzT6Lcx5frD0V30XieqJ0oX9I2Xj5aoMA==",
       "dev": true,
       "requires": {
         "ajv": "^6.12.4",
@@ -8140,9 +8143,9 @@
       }
     },
     "@types/express-serve-static-core": {
-      "version": "4.17.31",
-      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.31.tgz",
-      "integrity": "sha512-DxMhY+NAsTwMMFHBTtJFNp5qiHKJ7TeqOo23zVEM9alT1Ml27Q3xcTH0xwxn7Q0BbMcVEJOs/7aQtUWupUQN3Q==",
+      "version": "4.17.32",
+      "resolved": "https://registry.npmjs.org/@types/express-serve-static-core/-/express-serve-static-core-4.17.32.tgz",
+      "integrity": "sha512-aI5h/VOkxOF2Z1saPy0Zsxs5avets/iaiAJYznQFm5By/pamU31xWKL//epiF4OfUA2qTOc9PV6tCUjhO8wlZA==",
       "requires": {
         "@types/node": "*",
         "@types/qs": "*",
@@ -8817,9 +8820,9 @@
       "dev": true
     },
     "caniuse-lite": {
-      "version": "1.0.30001441",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001441.tgz",
-      "integrity": "sha512-OyxRR4Vof59I3yGWXws6i908EtGbMzVUi3ganaZQHmydk1iwDhRnvaPG2WaR0KcqrDFKrxVZHULT396LEPhXfg==",
+      "version": "1.0.30001445",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001445.tgz",
+      "integrity": "sha512-8sdQIdMztYmzfTMO6KfLny878Ln9c2M0fc7EH60IjlP4Dc4PiCy7K2Vl3ITmWgOyPgVQKa5x+UP/KqFsxj4mBg==",
       "dev": true
     },
     "canonicalize": {
@@ -8833,9 +8836,9 @@
       "integrity": "sha512-K7Qy8O9p76sL3/3m7/zLKbRkyOlSZAgzEaLhyj2mXS8PsCud2Eo4hAb8aLtZqHh0QGqLcb9dlJSu6lHRVENm1w=="
     },
     "cborg": {
-      "version": "1.9.6",
-      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.9.6.tgz",
-      "integrity": "sha512-XmiD+NWTk9xg31d8MdXgW46bSZd95ELllxjbjdWGyHAtpTw+cf8iG3NibWgTWRnfWfxtcihVa5Pm0gchHiO3JQ=="
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/cborg/-/cborg-1.10.0.tgz",
+      "integrity": "sha512-/eM0JCaL99HDHxjySNQJLaolZFVdl6VA0/hEKIoiQPcQzE5LrG5QHdml0HaBt31brgB9dNe1zMr3f8IVrpotRQ=="
     },
     "chalk": {
       "version": "4.1.2",
@@ -9307,27 +9310,33 @@
       }
     },
     "es-abstract": {
-      "version": "1.20.5",
-      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.20.5.tgz",
-      "integrity": "sha512-7h8MM2EQhsCA7pU/Nv78qOXFpD8Rhqd12gYiSJVkrH9+e8VuA8JlPJK/hQjjlLv6pJvx/z1iRFKzYb0XT/RuAQ==",
+      "version": "1.21.1",
+      "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.21.1.tgz",
+      "integrity": "sha512-QudMsPOz86xYz/1dG1OuGBKOELjCh99IIWHLzy5znUB6j8xG2yMA7bfTV86VSqKF+Y/H08vQPR+9jyXpuC6hfg==",
       "dev": true,
       "requires": {
+        "available-typed-arrays": "^1.0.5",
         "call-bind": "^1.0.2",
+        "es-set-tostringtag": "^2.0.1",
         "es-to-primitive": "^1.2.1",
         "function-bind": "^1.1.1",
         "function.prototype.name": "^1.1.5",
         "get-intrinsic": "^1.1.3",
         "get-symbol-description": "^1.0.0",
+        "globalthis": "^1.0.3",
         "gopd": "^1.0.1",
         "has": "^1.0.3",
         "has-property-descriptors": "^1.0.0",
+        "has-proto": "^1.0.1",
         "has-symbols": "^1.0.3",
-        "internal-slot": "^1.0.3",
+        "internal-slot": "^1.0.4",
+        "is-array-buffer": "^3.0.1",
         "is-callable": "^1.2.7",
         "is-negative-zero": "^2.0.2",
         "is-regex": "^1.1.4",
         "is-shared-array-buffer": "^1.0.2",
         "is-string": "^1.0.7",
+        "is-typed-array": "^1.1.10",
         "is-weakref": "^1.0.2",
         "object-inspect": "^1.12.2",
         "object-keys": "^1.1.1",
@@ -9336,7 +9345,20 @@
         "safe-regex-test": "^1.0.0",
         "string.prototype.trimend": "^1.0.6",
         "string.prototype.trimstart": "^1.0.6",
-        "unbox-primitive": "^1.0.2"
+        "typed-array-length": "^1.0.4",
+        "unbox-primitive": "^1.0.2",
+        "which-typed-array": "^1.1.9"
+      }
+    },
+    "es-set-tostringtag": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.0.1.tgz",
+      "integrity": "sha512-g3OMbtlwY3QewlqAiMLI47KywjWZoEytKr8pf6iTC8uJq5bIAH52Z9pnQ8pVL6whrCto53JZDuUIsifGeLorTg==",
+      "dev": true,
+      "requires": {
+        "get-intrinsic": "^1.1.3",
+        "has": "^1.0.3",
+        "has-tostringtag": "^1.0.0"
       }
     },
     "es-shim-unscopables": {
@@ -9484,13 +9506,14 @@
       }
     },
     "eslint-import-resolver-node": {
-      "version": "0.3.6",
-      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.6.tgz",
-      "integrity": "sha512-0En0w03NRVMn9Uiyn8YRPDKvWjxCWkslUEhGNTdGx15RvPJYQ+lbOlqrlNI2vEAs4pDYK4f/HN2TbDmk5TP0iw==",
+      "version": "0.3.7",
+      "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.7.tgz",
+      "integrity": "sha512-gozW2blMLJCeFpBwugLTGyvVjNoeo1knonXAcatC6bjPBZitotxdWf7Gimr25N4c0AAOo4eOUfaG82IJPDpqCA==",
       "dev": true,
       "requires": {
         "debug": "^3.2.7",
-        "resolve": "^1.20.0"
+        "is-core-module": "^2.11.0",
+        "resolve": "^1.22.1"
       },
       "dependencies": {
         "debug": {
@@ -9806,9 +9829,9 @@
       "dev": true
     },
     "fastq": {
-      "version": "1.14.0",
-      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.14.0.tgz",
-      "integrity": "sha512-eR2D+V9/ExcbF9ls441yIuN6TI2ED1Y2ZcA5BmMtJsOkWOFRJQ0Jt0g1UwqXJJVAb+V+umH5Dfr8oh4EVP7VVg==",
+      "version": "1.15.0",
+      "resolved": "https://registry.npmjs.org/fastq/-/fastq-1.15.0.tgz",
+      "integrity": "sha512-wBrocU2LCXXa+lWBt8RoIRD89Fi8OdABODa/kEnyeyjS5aZO5/GNvI5sEINADqP/h8M29UHTHUb53sUu5Ihqdw==",
       "dev": true,
       "requires": {
         "reusify": "^1.0.4"
@@ -10124,6 +10147,15 @@
         "type-fest": "^0.20.2"
       }
     },
+    "globalthis": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/globalthis/-/globalthis-1.0.3.tgz",
+      "integrity": "sha512-sFdI5LyBiNTHjRd7cGPWapiHWMOXKyuBNX/cWJ3NfzrZQVa8GI/8cofCl74AOVqq9W5kNmguTIzJ/1s2gyI9wA==",
+      "dev": true,
+      "requires": {
+        "define-properties": "^1.1.3"
+      }
+    },
     "globby": {
       "version": "11.1.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-11.1.0.tgz",
@@ -10201,6 +10233,12 @@
       "requires": {
         "get-intrinsic": "^1.1.1"
       }
+    },
+    "has-proto": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
+      "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "dev": true
     },
     "has-symbols": {
       "version": "1.0.3",
@@ -10407,6 +10445,17 @@
       "requires": {
         "call-bind": "^1.0.2",
         "has-tostringtag": "^1.0.0"
+      }
+    },
+    "is-array-buffer": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/is-array-buffer/-/is-array-buffer-3.0.1.tgz",
+      "integrity": "sha512-ASfLknmY8Xa2XtB4wmbz13Wu202baeA18cJBCeCy0wXUHZF0IPyVEXqKEcd+t2fNSLLL1vC6k7lxZEojNbISXQ==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "get-intrinsic": "^1.1.3",
+        "is-typed-array": "^1.1.10"
       }
     },
     "is-bigint": {
@@ -10692,9 +10741,9 @@
       "dev": true
     },
     "json5": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-      "integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/json5/-/json5-1.0.2.tgz",
+      "integrity": "sha512-g1MWMLBiz8FKi1e4w0UyVL3w+iJceWAFBAaBnnGKOpNa5f8TLktkbre1+s6oICydWAm+HRUGTmI+//xv2hvXYA==",
       "dev": true,
       "requires": {
         "minimist": "^1.2.0"
@@ -10840,14 +10889,6 @@
             "level-errors": "^2.0.0"
           }
         }
-      }
-    },
-    "level-read-stream": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/level-read-stream/-/level-read-stream-1.1.0.tgz",
-      "integrity": "sha512-pVRftTUgsJHH3O1o+cXRTZuRGPnTMyuocxpfl+b5L/papZhV810zhunAxn4mgvfDWzqxM5Df76z7C1Y0QQSLBw==",
-      "requires": {
-        "readable-stream": "^3.4.0"
       }
     },
     "level-supports": {
@@ -11034,7 +11075,7 @@
         "level": "8.0.0",
         "lodash": "4.17.21",
         "multiformats": "10.0.3",
-        "search-index": "3.3.0"
+        "search-index": "3.1.3"
       },
       "dependencies": {
         "@ipld/dag-cbor": {
@@ -11046,51 +11087,10 @@
             "multiformats": "^10.0.2"
           }
         },
-        "fergies-inverted-index": {
-          "version": "10.2.0",
-          "resolved": "https://registry.npmjs.org/fergies-inverted-index/-/fergies-inverted-index-10.2.0.tgz",
-          "integrity": "sha512-9j3Ckf8f0ydvt3JK5JyqQjiyPlR8H5HtLMV+RPJrpb6XRimM6OpKbA9pTsKNu0gpQdG5ezI9ld0ZrC9/FdksjQ==",
-          "requires": {
-            "browser-level": "^1.0.1",
-            "charwise": "^3.0.1",
-            "classic-level": "^1.2.0",
-            "level-read-stream": "^1.1.0",
-            "traverse": "^0.6.6"
-          }
-        },
         "multiformats": {
           "version": "10.0.3",
           "resolved": "https://registry.npmjs.org/multiformats/-/multiformats-10.0.3.tgz",
           "integrity": "sha512-K2yGSmstS/oEmYiEIieHb53jJCaqp4ERPDQAYrm5sV3UUrVDZeshJQCK6GHAKyIGufU1vAcbS0PdAAZmC7Tzcw=="
-        },
-        "p-queue": {
-          "version": "7.3.0",
-          "resolved": "https://registry.npmjs.org/p-queue/-/p-queue-7.3.0.tgz",
-          "integrity": "sha512-5fP+yVQ0qp0rEfZoDTlP2c3RYBgxvRsw30qO+VtPPc95lyvSG+x6USSh1TuLB4n96IO6I8/oXQGsTgtna4q2nQ==",
-          "requires": {
-            "eventemitter3": "^4.0.7",
-            "p-timeout": "^5.0.2"
-          }
-        },
-        "p-timeout": {
-          "version": "5.1.0",
-          "resolved": "https://registry.npmjs.org/p-timeout/-/p-timeout-5.1.0.tgz",
-          "integrity": "sha512-auFDyzzzGZZZdHz3BtET9VEz0SE/uMEAx7uWfGPucfzEwwe/xH0iVeZibQmANYE/hp9T2+UUZT5m+BKyrDp3Ew=="
-        },
-        "search-index": {
-          "version": "3.3.0",
-          "resolved": "https://registry.npmjs.org/search-index/-/search-index-3.3.0.tgz",
-          "integrity": "sha512-VJJfhXGXdwtu7/lf/bDMb4gN3mqXhSm57VUZBzRsOtIDvTVSPaOWJZYfruMIqutp+N4aLdUOUfWhB02MClmIJQ==",
-          "requires": {
-            "browser-level": "^1.0.1",
-            "classic-level": "^1.2.0",
-            "fergies-inverted-index": "^10.1.0",
-            "level-read-stream": "^1.1.0",
-            "lru-cache": "^7.9.0",
-            "ngraminator": "^3.0.1",
-            "p-queue": "^7.2.0",
-            "term-vector": "^1.0.0"
-          }
         }
       }
     },
@@ -11261,9 +11261,9 @@
       }
     },
     "node-gyp-build": {
-      "version": "4.5.0",
-      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.5.0.tgz",
-      "integrity": "sha512-2iGbaQBV+ITgCz76ZEjmhUKAKVf7xfY1sRl4UiKQspfZMH2h06SyhNsnSVy50cwkFQDGLyif6m/6uFXHkOZ6rg=="
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/node-gyp-build/-/node-gyp-build-4.6.0.tgz",
+      "integrity": "sha512-NTZVKn9IylLwUzaKjkas1e4u2DLNcV4rdYagA4PWdPwW87Bi7z+BznyKSRwS/761tV/lzCGXplWsiaMjLqP2zQ=="
     },
     "node-releases": {
       "version": "2.0.8",
@@ -11304,9 +11304,9 @@
       "dev": true
     },
     "object-inspect": {
-      "version": "1.12.2",
-      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.2.tgz",
-      "integrity": "sha512-z+cPxW0QGUp0mcqcsgQyLVRDoXFQbXOwBaqyF7VIgI4TWNQsDHrBpUQslRmIfAoYWdYzs6UlKJtB2XJpTaNSpQ==",
+      "version": "1.12.3",
+      "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.12.3.tgz",
+      "integrity": "sha512-geUvdk7c+eizMNUDkRpW1wJwgfOiOeHbxBR/hLXK1aT6zmVSO0jsQcs7fj6MGw89jC/cjGfLcNOrtMYtGqm81g==",
       "dev": true
     },
     "object-is": {
@@ -11497,9 +11497,9 @@
       "dev": true
     },
     "postcss": {
-      "version": "8.4.20",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.20.tgz",
-      "integrity": "sha512-6Q04AXR1212bXr5fh03u8aAwbLxAQNGQ/Q1LNa0VfOI06ZAlhPHtQvE4OIdpj4kLThXilalPnmDSOD65DcHt+g==",
+      "version": "8.4.21",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.21.tgz",
+      "integrity": "sha512-tP7u/Sn/dVxK2NnruI4H9BG+x+Wxz6oeZ1cJ8P6G/PZY0IKk4k/63TDsQf2kQq3+qoJeLm2kIBUNlZe3zgb4Zg==",
       "requires": {
         "nanoid": "^3.3.4",
         "picocolors": "^1.0.0",
@@ -12177,9 +12177,9 @@
       "integrity": "sha512-E/ZsdU4HLs/68gYzgGTkMicWTLPdAftJLfJFlLUAAKZGkStNU72sZjT66SnMDVOfOWY/YAoiD7Jxa9iHvngcag=="
     },
     "punycode": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.2.0.tgz",
+      "integrity": "sha512-LN6QV1IJ9ZhxWTNdktaPClrNfp8xdSAYS0Zk2ddX7XsXZAxckMHPCBcHRo0cTcEIgYPRiGEkmji3Idkh2yFtYw=="
     },
     "q": {
       "version": "1.5.1",
@@ -12363,9 +12363,9 @@
       }
     },
     "rollup": {
-      "version": "3.9.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.9.0.tgz",
-      "integrity": "sha512-nGGylpmblyjTpF4lEUPgmOw6OVxRvnI6Iuuh6Lz4O/X66cVOX1XJSsqP1YamxQ+mPuFE7qJxLFDSCk8rNv5dDw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/rollup/-/rollup-3.10.0.tgz",
+      "integrity": "sha512-JmRYz44NjC1MjVF2VKxc0M1a97vn+cDxeqWmnwyAF4FvpjK8YFdHpaqvQB+3IxCvX05vJxKZkoMDU8TShhmJVA==",
       "dev": true,
       "requires": {
         "fsevents": "~2.3.2"
@@ -13050,6 +13050,17 @@
         "mime-types": "~2.1.24"
       }
     },
+    "typed-array-length": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/typed-array-length/-/typed-array-length-1.0.4.tgz",
+      "integrity": "sha512-KjZypGq+I/H7HI5HlOoGHkWUUGq+Q0TPhQurLbyrVrvnKTBgzLhIJ7j6J/XTQOi0d1RjyZ0wdas8bKs2p0x3Ng==",
+      "dev": true,
+      "requires": {
+        "call-bind": "^1.0.2",
+        "for-each": "^0.3.3",
+        "is-typed-array": "^1.1.9"
+      }
+    },
     "uint8arrays": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/uint8arrays/-/uint8arrays-3.1.1.tgz",
@@ -13182,9 +13193,9 @@
       "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg=="
     },
     "vite": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.3.tgz",
-      "integrity": "sha512-HvuNv1RdE7deIfQb8mPk51UKjqptO/4RXZ5yXSAvurd5xOckwS/gg8h9Tky3uSbnjYTgUm0hVCet1cyhKd73ZA==",
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-4.0.4.tgz",
+      "integrity": "sha512-xevPU7M8FU0i/80DMR+YhgrzR5KS2ORy1B4xcX/cXLsvnUWvfHuqMmVU6N0YiJ4JWGRJJsLCgjEzKjG9/GKoSw==",
       "dev": true,
       "requires": {
         "esbuild": "^0.16.3",

--- a/web5-wallet/package.json
+++ b/web5-wallet/package.json
@@ -19,7 +19,7 @@
     "@decentralized-identity/ion-tools": "1.0.3",
     "@js-temporal/polyfill": "0.4.3",
     "@noble/ed25519": "1.6.0",
-    "@tbd54566975/dwn-sdk-js": "0.0.16",
+    "@tbd54566975/dwn-sdk-js": "0.0.17-unstable.4deecf8-2023.1.17-19-06-19",
     "dayjs": "1.11.7",
     "eventemitter3": "4.0.7",
     "multiformats": "9.6.4",

--- a/web5-wallet/ui/src/components/CreateProfileForm.vue
+++ b/web5-wallet/ui/src/components/CreateProfileForm.vue
@@ -21,8 +21,6 @@ async function createProfile() {
     };
   }
 
-  console.log(payload);
-
   const resp = await BackgroundRequest.post('/profiles', payload);
 
   // TODO: handle non-201 status codes


### PR DESCRIPTION
Duplicated todo upon refresh bug is caused by difference in behavior between search-index 3.1.3 and 3.3.0. Downgraded to 3.1.3 fixes the issue. Long term we'd want to deprecate search-index altogether.