### PR TITLE
Fix dead link in chat-app README

### DIFF
--- a/chat-app/README.md
+++ b/chat-app/README.md
@@ -5,9 +5,9 @@ This trivial chat app uses an addressable DWN (other approaches will soon be ava
 ## Building and Running Chat app
 
 ### Prerequites:
-- Run: `cd message-store-level-v2 && npm install && node bundle.js`<br. />
+- Run: `cd message-store-level-v2 && npm install && node bundle.js`<br />
 This will install the message-store-level-v2 patch (temporary) 
-- Build and then install the web5-wallet into chrome, follow the instructions [here](./web5-wallet/README.md)
+- Build and then install the web5-wallet into chrome, follow the instructions [here](../web5-wallet/README.md)
 - Build and run the addressable DWN in a separate termional window: instructions [here](../addressable-dwn/README.md)
 - Run: `ngrok http 3000` <br />
 This will use [ngrok](https://ngrok.com/) to open a public port to your local DWN - take note of the public https URL that it returns. You'll need this later.


### PR DESCRIPTION
Hello TBD! I went through the instructions for the chat app and ran into a couple typos in the README.